### PR TITLE
refactor: Display progress in single line

### DIFF
--- a/app/Plugin/GitHub/Sync.php
+++ b/app/Plugin/GitHub/Sync.php
@@ -91,8 +91,10 @@ class Sync extends Command {
         }
       }
 
-      print '.' . PHP_EOL;
+      print '.';
     }
+
+    print PHP_EOL;
 
     $diff = array_diff_key($github_unread, $github_notifications_unread);
     foreach (array_keys($diff) as $id) {


### PR DESCRIPTION
Remove the `PHP_EOL` from being appended to every
notification that is processed.